### PR TITLE
Allow PHP 8 and Symfony 7 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ version: 2.1
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
 orbs:
-  coveralls: coveralls/coveralls@2.2.1
+  coveralls: coveralls/coveralls@2.2.5
 jobs:
   default:
     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/configuration-reference/#executor-job
     docker:
-      - image: cimg/php:8.2
+      - image: cimg/php:8.4
     # Add steps to the job
     # See: https://circleci.com/docs/configuration-reference/#steps
     steps:

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     "chgst/chgst": "^0.3.3"
   },
   "require-dev": {
-    "phpspec/phpspec": "^7.4",
+    "phpspec/phpspec": "^8.0.0",
     "pdepend/pdepend": "^2.15",
     "phploc/phploc": "^7.0.2",
     "phpmd/phpmd": "^2.14.1",
     "sebastian/phpcpd": "^6.0.3",
-    "friends-of-phpspec/phpspec-code-coverage": "^v6.3.0",
+    "friends-of-phpspec/phpspec-code-coverage": "^v7.0.0",
     "php-coveralls/php-coveralls": "^v2.6.0",
     "symfony/expression-language": "^7.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
   "description": "Symfony bundle for chgst",
   "type": "library",
   "require": {
-    "php": "^8.2",
-    "symfony/config": "~6",
-    "symfony/security-bundle": "~6",
+    "php": "^8.0",
+    "symfony/config": "^7.0",
+    "symfony/security-bundle": "^7.0",
     "chgst/chgst": "^0.3.3"
   },
   "require-dev": {
@@ -14,10 +14,9 @@
     "phploc/phploc": "^7.0.2",
     "phpmd/phpmd": "^2.14.1",
     "sebastian/phpcpd": "^6.0.3",
-    "symfony/templating": "~6",
     "friends-of-phpspec/phpspec-code-coverage": "^v6.3.0",
     "php-coveralls/php-coveralls": "^v2.6.0",
-    "symfony/expression-language": "~v6.3.0"
+    "symfony/expression-language": "^7.0"
   },
   "license": "MIT",
   "minimum-stability": "stable",
@@ -31,9 +30,5 @@
       "spec\\Chgst\\ChgstBundle\\": "spec/"
     }
   },
-  "config": {
-    "platform": {
-      "php": "8.2"
-    }
-  }
+  "config": {}
 }

--- a/src/Command/ReplayStreamCommand.php
+++ b/src/Command/ReplayStreamCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 class ReplayStreamCommand extends Command
 {
+    protected static $defaultName = 'replay:stream';
+
     private RepositoryInterface $repository;
 
     private EventBusInterface $eventBus;
@@ -30,12 +32,11 @@ class ReplayStreamCommand extends Command
     public function configure(): void
     {
         $this
-            ->setName('replay:stream')
             ->setDescription('Replays events for event store to trigger projectors')
         ;
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->eventBus->disableListeners();
         $output->writeln('<fg=green>[chgst]</> Replaying all events in the event stream');
@@ -67,5 +68,7 @@ class ReplayStreamCommand extends Command
         }
 
         $output->writeln(sprintf(' processed %d items', $totalCounter));
+
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
## Summary
- update package constraints to support PHP 8.0+ and target Symfony 7 packages
- remove platform PHP pin to avoid blocking installations on newer PHP 8 versions

## Testing
- composer validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303dc001d8832a96b11654793b8dfd)